### PR TITLE
initial skeleton for Dial plugin

### DIFF
--- a/plugins/Dial/__init__.py
+++ b/plugins/Dial/__init__.py
@@ -1,0 +1,34 @@
+"""
+"""
+
+import supybot
+import supybot.world as world
+
+# Use this for the version of this plugin.  You may wish to put a CVS keyword
+# in here if you're keeping the plugin in CVS or some similar system.
+__version__ = ""
+
+# an appropriate author or supybot.Author instance.
+__author__ = supybot.Author("#ARG")
+
+# This is a dictionary mapping supybot.Author instances to lists of
+# contributions.
+__contributors__ = {}
+
+# This is a url where the most recent plugin package can be downloaded.
+__url__ = ''
+
+from . import config
+from . import plugin
+from imp import reload
+# In case we're being reloaded.
+reload(config)
+reload(plugin)
+# Add more reloads here if you add third-party modules and want them to be
+# reloaded when this plugin is reloaded.  Don't forget to import them as well!
+
+if world.testing:
+    from . import test
+
+Class = plugin.Class
+configure = config.configure

--- a/plugins/Dial/config.py
+++ b/plugins/Dial/config.py
@@ -1,0 +1,23 @@
+import supybot.conf as conf
+import supybot.registry as registry
+try:
+    from supybot.i18n import PluginInternationalization
+    _ = PluginInternationalization('Dial')
+except:
+    # Placeholder that allows to run the plugin on a bot
+    # without the i18n module
+    _ = lambda x:x
+
+def configure(advanced):
+    # This will be called by supybot to configure this module.  advanced is
+    # a bool that specifies whether the user identified themself as an advanced
+    # user or not.  You should effect your configuration by manipulating the
+    # registry as appropriate.
+    from supybot.questions import expect, anything, something, yn
+    conf.registerPlugin('Dial', True)
+
+
+Dial = conf.registerPlugin('Dial')
+# This is where your configuration variables (if any) should go.  For example:
+# conf.registerGlobalValue(Dial, 'someConfigVariableName',
+#     registry.Boolean(False, _("""Help for someConfigVariableName.""")))

--- a/plugins/Dial/local/__init__.py
+++ b/plugins/Dial/local/__init__.py
@@ -1,0 +1,1 @@
+# Stub so local is a module, used for third-party modules

--- a/plugins/Dial/plugin.py
+++ b/plugins/Dial/plugin.py
@@ -1,0 +1,40 @@
+import re
+import supybot.utils as utils
+from supybot.commands import *
+import supybot.plugins as plugins
+import supybot.ircutils as ircutils
+import supybot.callbacks as callbacks
+try:
+    from supybot.i18n import PluginInternationalization
+    _ = PluginInternationalization('Dial')
+except ImportError:
+    # Placeholder that allows to run the plugin on a bot
+    # without the i18n module
+    _ = lambda x:x
+
+
+def normalize_number(text):
+    return re.sub("[+\- ]", "", text)
+
+
+class Dial(callbacks.Plugin):
+    """Each instance represents one load of the supybot plugin.
+    """
+    def __init__(self, irc):
+        super(Dial, self).__init__(irc)
+
+    def dial(self, irc, msg, args):
+        """
+        """
+        arg = " ".join(args).strip()
+        arg = normalize_number(arg)
+        if not arg:
+            formatted = "Give a phone number to dial"
+        elif not re.match("^\d{10,11}\Z", arg):
+            formatted = "Give a valid phone number to dial (10-11 digits)"
+        else:
+            formatted = "Would queue a dial to {0}".format(arg)
+        irc.reply(formatted)
+
+
+Class = Dial

--- a/plugins/Dial/test.py
+++ b/plugins/Dial/test.py
@@ -1,0 +1,4 @@
+from supybot.test import *
+
+class DialTestCase(PluginTestCase):
+    plugins = ('Dial',)


### PR DESCRIPTION
Stub for implementation of '_@_dial' command. This stub does not dial.

I think implementation would ultimately just be a POST to the dialer. As-is that might require parsing the dialer's page to get the integer code to actually submit. On our end we probably want to precheck that the number is on a whitelist before allowing the irc-originated dial to be submitted to dialer, so that we can tell user up front when we know it's not going to be accepted.

Otherwise, I don't think this needs any kind of reporting on eventual success.

It might be nice for the implementation not to even do the HTTP request to dialer, just throw it on a queue. On the other side of the queue can be whatever kind of worker we want, whatever language.
